### PR TITLE
base: `compile-string` method useful for inital tests and debugging

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --type=bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+git diff-index --check --cached $against -- || exit 1
+
+# ninja build and run tests
+ninja -v run-tests || exit 1
+exec ./run-tests

--- a/src/base.scm
+++ b/src/base.scm
@@ -1,7 +1,17 @@
 (define-library
   (epsilon base)
   (import scheme r7rs)
-  (export compile-program)
+  (export
+    compile
+    compile-string)
+
   (begin
-    (define (compile-program program)
-      (display "not implemented\n"))))
+    (define (compile program)
+      (write-string "\a"))
+
+    (define (compile-string program)
+      (parameterize
+        ((current-output-port
+           (open-output-string)))
+        (compile program)
+        (get-output-string (current-output-port))))))

--- a/src/epsilon.scm
+++ b/src/epsilon.scm
@@ -6,4 +6,4 @@
     r7rs
     (epsilon base))
   (begin
-    (compile-program '())))
+    (compile '())))

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -3,10 +3,15 @@
   (import
     scheme
     r7rs
-    test)
+    test
+    (epsilon base))
+
   (begin
     (test-group
-      "example tests"
-      (test "test equal: 2 (+ 1 1)" 2 (+ 1 1))
-      (test-assert "assert true: (= 1 1)" (= 1 1)))
+      "compile-string"
+      (test
+        "BEL char returned by `compile-string`"
+        "\a"
+        (compile-string '())))
+
     (test-exit)))


### PR DESCRIPTION
includes a simple test and a git hook for running the tests before passing commits